### PR TITLE
Make gzip-compression optional.

### DIFF
--- a/stream/stream.py
+++ b/stream/stream.py
@@ -16,7 +16,7 @@ from google.protobuf.internal.decoder import _DecodeVarint as decodeVarint
 from google.protobuf.internal.encoder import _EncodeVarint as encodeVarint
 
 
-def parse(fpath, pb_cls):
+def parse(fpath, pb_cls, gzip=True):
     """Parse a stream.
 
     Args:
@@ -24,7 +24,7 @@ def parse(fpath, pb_cls):
         pb_cls (protobuf.message.Message.__class__): The class object of
             the protobuf message type encoded in the stream.
     """
-    with open(fpath, 'rb') as istream:
+    with open(fpath, 'rb', gzip=gzip) as istream:
         for data in istream:
             pb_obj = pb_cls()
             pb_obj.ParseFromString(data)
@@ -97,7 +97,11 @@ class Stream(object):
                 True by yielding a delimiter after reading each group.
             delimiter_cls (class): delimiter class.
         """
-        self._fd = gzip.open(fpath, mode)
+        if kwargs.get('gzip', True):
+            self._fd = gzip.open(fpath, mode)
+        else:
+            import builtins
+            self._fd = builtins.open(fpath, mode)
         if not mode.startswith('r'):
             self._buffer_size = kwargs.pop('buffer_size', 0)
             self._write_buff = []

--- a/stream/stream.py
+++ b/stream/stream.py
@@ -96,6 +96,8 @@ class Stream(object):
             group_delimiter (boolean): indicate the end of a message group if
                 True by yielding a delimiter after reading each group.
             delimiter_cls (class): delimiter class.
+            gzip (bool): Whether or not to use gzip compression on the given
+                file. (default is True)
         """
         if kwargs.get('gzip', True):
             self._fd = gzip.open(fpath, mode)

--- a/test/test_stream.py
+++ b/test/test_stream.py
@@ -59,7 +59,7 @@ def read_alns2(fpath, gzip=True):
     assert nof_groups == 2
 
 
-def write_objs1(fpath, *objs_list, **kwds):
+def write_objs1(fpath, *objs_list, **kwargs):
     """Write protobuf message objects into the file by using `with` statement.
 
     It writes half of them in one group, and then the other half in another one.
@@ -68,13 +68,13 @@ def write_objs1(fpath, *objs_list, **kwds):
         fpath (string): path of the file to be written.
         objs_list (*protobuf.message.Message): list of objects to be written.
     """
-    with stream.open(fpath, 'wb', gzip=kwds.get('gzip', True)) as ostream:
+    with stream.open(fpath, 'wb', gzip=kwargs.get('gzip', True)) as ostream:
         length = len(objs_list)
         ostream.write(*objs_list[:length//2])
         ostream.write(*objs_list[length//2:])
 
 
-def write_objs2(fpath, *objs_list, **kwds):
+def write_objs2(fpath, *objs_list, **kwargs):
     """Write protobuf message objects into the file w/o using `with` statement.
 
     It writes half of them in one group, and then the other half in another one
@@ -86,7 +86,7 @@ def write_objs2(fpath, *objs_list, **kwds):
         fpath (string): path of the file to be written.
         objs_list (*protobuf.message.Message): list of objects to be written.
     """
-    ostream = stream.open(fpath, 'wb', buffer_size=(len(objs_list)//2), gzip=kwds.get('gzip', True))
+    ostream = stream.open(fpath, 'wb', buffer_size=(len(objs_list)//2), gzip=kwargs.get('gzip', True))
     ostream.write(*objs_list)
     ostream.close()
 

--- a/test/test_stream.py
+++ b/test/test_stream.py
@@ -86,7 +86,8 @@ def write_objs2(fpath, *objs_list, **kwargs):
         fpath (string): path of the file to be written.
         objs_list (*protobuf.message.Message): list of objects to be written.
     """
-    ostream = stream.open(fpath, 'wb', buffer_size=(len(objs_list)//2), gzip=kwargs.get('gzip', True))
+    ostream = stream.open(fpath, 'wb', buffer_size=(len(objs_list)//2),
+                          gzip=kwargs.get('gzip', True))
     ostream.write(*objs_list)
     ostream.close()
 


### PR DESCRIPTION
To be able to read in ordinary protocol buffer data as a stream, rather than just one produced with the same Python module, gzip-compression needs to be optional. This PR does that: it adds a `gzip` keyword argument, defaulting to `True` for backwards-compatibility.